### PR TITLE
fix: default disk encryption key type to RSA

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -57,7 +57,7 @@
 | key\_opts | List of key operations for Key Vault keys | `list(string)` | <pre>[<br>  "decrypt",<br>  "encrypt",<br>  "sign",<br>  "unwrapKey",<br>  "verify",<br>  "wrapKey"<br>]</pre> | no |
 | key\_permissions | List of Key Vault key permissions | `list(string)` | <pre>[<br>  "Create",<br>  "Delete",<br>  "Get",<br>  "Purge",<br>  "Recover",<br>  "Update",<br>  "WrapKey",<br>  "UnwrapKey",<br>  "List",<br>  "Decrypt",<br>  "Sign"<br>]</pre> | no |
 | key\_size | Size of the RSA key in bytes (e.g., 1024, 2048). | `number` | `2048` | no |
-| key\_type | The Key Type for Key Vault. Possible values: EC, EC-HSM, RSA, RSA-HSM. | `string` | `"RSA-HSM"` | no |
+| key\_type | The Key Type for Key Vault. Possible values: EC, EC-HSM, RSA, RSA-HSM. Use an HSM key type only with a premium or HSM-capable Key Vault. | `string` | `"RSA"` | no |
 | key\_vault\_id | The ID of the Key Vault for disk encryption. | `any` | `null` | no |
 | key\_vault\_rbac\_auth\_enabled | Whether to use RBAC authorization for Key Vault instead of access policies. | `bool` | `true` | no |
 | label\_order | The order of labels used to construct resource names or tags. If not specified, defaults to ['name', 'environment', 'location']. | `list(any)` | <pre>[<br>  "name",<br>  "environment",<br>  "location"<br>]</pre> | no |
@@ -139,4 +139,3 @@
 | service\_vault\_tenant\_id | The Tenant ID associated with this Managed Service Identity. |
 | vm\_backup\_policy\_id | The ID of the VM Backup Policy. |
 | windows\_virtual\_machine\_id | The ID of the Windows Virtual Machine. |
-

--- a/variables.tf
+++ b/variables.tf
@@ -611,8 +611,8 @@ variable "vault_sku" {
 
 variable "key_type" {
   type        = string
-  default     = "RSA-HSM"
-  description = "The Key Type for Key Vault. Possible values: EC, EC-HSM, RSA, RSA-HSM."
+  default     = "RSA"
+  description = "The Key Type for Key Vault. Possible values: EC, EC-HSM, RSA, RSA-HSM. Use an HSM key type only with a premium or HSM-capable Key Vault."
 }
 
 variable "key_size" {


### PR DESCRIPTION
## Summary
- change the default  from  to 
- document that HSM key types require a premium or HSM-capable Key Vault
- update the tracked inputs documentation

## Why
The current module default creates an HSM-backed key when . That fails against a standard Key Vault with . Defaulting to  keeps the module compatible with standard Key Vault deployments while still allowing callers to opt into  explicitly when they use a premium vault.

## Validation
- 
